### PR TITLE
fix: hide subscription page

### DIFF
--- a/lib/pages/settings/settings_view.dart
+++ b/lib/pages/settings/settings_view.dart
@@ -162,12 +162,12 @@ class SettingsView extends StatelessWidget {
               onTap: () => context.go('/rooms/settings/addbridgebot'),
               trailing: const Icon(Icons.chevron_right_outlined),
             ),
-            ListTile(
-              leading: const Icon(Icons.credit_card),
-              title: Text(L10n.of(context)!.subscription),
-              onTap: () => context.go('/rooms/settings/subs'),
-              trailing: const Icon(Icons.chevron_right_outlined),
-            ),
+            // ListTile(
+            //   leading: const Icon(Icons.credit_card),
+            //   title: Text(L10n.of(context)!.subscription),
+            //   onTap: () => context.go('/rooms/settings/subs'),
+            //   trailing: const Icon(Icons.chevron_right_outlined),
+            // ),
             ListTile(
               leading: const Icon(Icons.format_paint_outlined),
               title: Text(L10n.of(context)!.changeTheme),


### PR DESCRIPTION
The subscription page confuses users and sometimes leads to NPE issues.

![image](https://github.com/Tawkie/tawkie-app/assets/23584745/bae05b3f-8600-42b0-bd78-cd1aaf15be8b)
