### PR TITLE
fix url redirect pattern

### DIFF
--- a/lib/pages/add_bridge/model/social_network.dart
+++ b/lib/pages/add_bridge/model/social_network.dart
@@ -14,6 +14,7 @@ class SocialNetwork {
       displayNameSuffix; // The `(Network)` suffix to remove from displayname)
   final String? urlLogin;
   final String? urlRedirect;
+  final RegExp? urlRedirectPattern;
   bool loading; // To find out if state is loading
   bool connected; // To find out if state is disconnected
   bool error; // Bool to indicate if there is an error
@@ -29,6 +30,7 @@ class SocialNetwork {
     this.displayNameSuffix = "",
     this.urlLogin,
     this.urlRedirect,
+    this.urlRedirectPattern,
     this.loading = true, // Default value true for loading
     this.connected = false, // Default value false for connected
     this.error = false, // Défaut à false
@@ -77,6 +79,7 @@ class SocialNetworkManager {
       mxidPrefix: "@messenger2_",
       urlLogin: "https://www.messenger.com/login/",
       urlRedirect: "https://www.messenger.com/t/",
+      urlRedirectPattern: RegExp(r'^https:\/\/www\.messenger\.com\/.*\/t\/.*$'),
     ),
     SocialNetwork(
       logo: Logo(Logos.instagram),
@@ -89,6 +92,7 @@ class SocialNetworkManager {
       mxidPrefix: "@instagram2_",
       urlLogin: "https://www.instagram.com/accounts/login/",
       urlRedirect: "https://www.instagram.com/",
+      urlRedirectPattern: RegExp(r'^https:\/\/www\.instagram\.com\/.*$'),
     ),
     SocialNetwork(
       logo: Logo(Logos.whatsapp),
@@ -111,6 +115,7 @@ class SocialNetworkManager {
       mxidPrefix: "@linkedin_",
       urlLogin: "https://www.linkedin.com/login/",
       urlRedirect: "https://www.linkedin.com/feed/",
+      urlRedirectPattern: RegExp(r'^https:\/\/www\.linkedin\.com\/feed\/.*$'),
     ),
     SocialNetwork(
       logo: Container(),

--- a/lib/pages/add_bridge/web_view_connection.dart
+++ b/lib/pages/add_bridge/web_view_connection.dart
@@ -108,13 +108,14 @@ class _WebViewConnectionState extends State<WebViewConnection> {
           _webViewController = controller;
         },
         onLoadStop: (InAppWebViewController controller, Uri? url) async {
+          final urlString = url?.toString();
           // Check the URL when the page finishes loading
           switch (widget.network.name) {
             case "Facebook Messenger":
               final successfullyRedirected = !_facebookBridgeCreated &&
                   url != null &&
-                  url.toString() != widget.network.urlLogin! &&
-                  url.toString().contains(widget.network.urlRedirect!);
+                  urlString != widget.network.urlLogin! &&
+                  widget.network.urlRedirectPattern?.hasMatch(urlString!) == true;
 
               if (successfullyRedirected) {
                 await _closeWebView();
@@ -138,8 +139,8 @@ class _WebViewConnectionState extends State<WebViewConnection> {
             case "Instagram":
               if (!_instagramBridgeCreated &&
                   url != null &&
-                  url.toString() != widget.network.urlLogin! &&
-                  url.toString().contains(widget.network.urlRedirect!)) {
+                  urlString != widget.network.urlLogin! &&
+                  widget.network.urlRedirectPattern?.hasMatch(urlString!) == true) {
                 // Close the WebView
                 await _closeWebView();
                 await showCustomLoadingDialog(
@@ -158,7 +159,7 @@ class _WebViewConnectionState extends State<WebViewConnection> {
             case "Linkedin":
               if (!_linkedinBridgeCreated &&
                   url != null &&
-                  url.toString().contains(widget.network.urlRedirect!)) {
+                  widget.network.urlRedirectPattern?.hasMatch(urlString!) == true) {
                 // Close the WebView
                 await _closeWebView();
                 await showCustomLoadingDialog(


### PR DESCRIPTION
The app no longer recognized the Messenger redirect URL after successful login and before bridge creation, as this URL may have been modified by Meta.

I set up regular expressions to check these precise redirect moments while keeping the basic redirect URLs to retrieve the cookies later.