### PR TITLE
Build windows release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -295,7 +295,9 @@ jobs:
 
       - name: Get tag
         id: tag
-        run: echo "::set-output name=tag::`git describe --tags`"
+        run: |
+          echo "TAG=$(git describe --tags)" >> $GITHUB_ENV
+        shell: bash
 
       - name: Post-build Windows operations
         run: ./scripts/build-windows.ps1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -313,7 +313,7 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: "tawkie-windows.tar.gz"
-          asset_name: "tawkie-windows-${{ steps.tag.outputs.tag }}.tar.gz"
+          asset_name: "tawkie-windows-${{ env.TAG }}.tar.gz"
           asset_content_type: application/gzip
         # Upload the archive on the GitHub release page as an asset
 


### PR DESCRIPTION
To fix the error:

Run echo "::set-output name=tag::`git describe --tags`"
ParserError: D:\a\_temp\[9](https://github.com/Tawkie/tawkie-app/actions/runs/11015987000/job/30593609065#step:9:10)6f7cb57-19a3-4058-b760-460c39b95ab4.ps1:2
Line |
   2 |  echo "::set-output name=tag::`git describe --tags`"
     |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The string is missing the terminator: ".
Error: Process completed with exit code 1.